### PR TITLE
Implicit auth fix

### DIFF
--- a/src/Solomobro.Instagram.Tests/Solomobro.Instagram.Tests.csproj
+++ b/src/Solomobro.Instagram.Tests/Solomobro.Instagram.Tests.csproj
@@ -34,8 +34,24 @@
       <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="nunit.core, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\nunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="nunit.core.interfaces, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\nunit.core.interfaces.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="nunit.util, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\nunit.util.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NUnit.VisualStudio.TestAdapter, Version=2.0.0.0, Culture=neutral, PublicKeyToken=4cb40d35494691ac, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\NUnit.VisualStudio.TestAdapter.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Solomobro.Instagram.Tests/packages.config
+++ b/src/Solomobro.Instagram.Tests/packages.config
@@ -2,4 +2,5 @@
 <packages>
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
   <package id="NUnit" version="2.6.4" targetFramework="net452" />
+  <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net452" />
 </packages>

--- a/src/Solomobro.Instagram.WebApiDemo/Controllers/AuthorizeController.cs
+++ b/src/Solomobro.Instagram.WebApiDemo/Controllers/AuthorizeController.cs
@@ -34,22 +34,22 @@ namespace Solomobro.Instagram.WebApiDemo.Controllers
 
                 if (result.Success)
                 {
-                    return Redirect("http://localhost:56841/LoggedIn.html");
+                    return Redirect("http://localhost:8012/LoggedIn.html");
                 }
                 else
                 {
-                    return Redirect("http://localhost:/56841/Failed.html");
+                    return Redirect("http://localhost:8012/Failed.html");
                 }
             }
             catch (Exception)
             {
-                return Redirect("http://localhost:/56841/Failed.html");
+                return Redirect("http://localhost:8012/Failed.html");
             }
         }
 
         private OAuth GetInstagramAuthenticator()
         {
-            return new OAuth(AuthSettings.InstaClientID, AuthSettings.InstaClientSecret, AuthSettings.InstaRedirectUrl);
+            return new OAuth(AuthSettings.InstaClientID, AuthSettings.InstaClientSecret, AuthSettings.InstaRedirectUrl, AuthenticationMethod.Implicit);
         }
     }
 }

--- a/src/Solomobro.Instagram.WebApiDemo/Properties/Settings.Designer.cs
+++ b/src/Solomobro.Instagram.WebApiDemo/Properties/Settings.Designer.cs
@@ -25,7 +25,7 @@ namespace Solomobro.Instagram.WebApiDemo.Properties {
         
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("c:\\users\\alpha\\dev\\instagramsettings.data")]
+        [global::System.Configuration.DefaultSettingValueAttribute("C:\\Projects\\Instagram\\src\\Solomobro.Instagram.WebApiDemo\\Settings.txt")]
         public string InstagramSetingsFilePath {
             get {
                 return ((string)(this["InstagramSetingsFilePath"]));

--- a/src/Solomobro.Instagram.WebApiDemo/Properties/Settings.settings
+++ b/src/Solomobro.Instagram.WebApiDemo/Properties/Settings.settings
@@ -3,7 +3,7 @@
   <Profiles />
   <Settings>
     <Setting Name="InstagramSetingsFilePath" Type="System.String" Scope="Application">
-      <Value Profile="(Default)">c:\users\alpha\dev\instagramsettings.data</Value>
+      <Value Profile="(Default)">C:\Projects\Instagram\src\Solomobro.Instagram.WebApiDemo\Settings.txt</Value>
     </Setting>
   </Settings>
 </SettingsFile>

--- a/src/Solomobro.Instagram.WebApiDemo/Web.config
+++ b/src/Solomobro.Instagram.WebApiDemo/Web.config
@@ -51,7 +51,7 @@
   <applicationSettings>
     <Solomobro.Instagram.WebApiDemo.Properties.Settings>
       <setting name="InstagramSetingsFilePath" serializeAs="String">
-        <value>c:\users\alpha\dev\instagramsettings.data</value>
+        <value>C:\Projects\Instagram\src\Solomobro.Instagram.WebApiDemo\Settings.txt</value>
       </setting>
     </Solomobro.Instagram.WebApiDemo.Properties.Settings>
   </applicationSettings>

--- a/src/Solomobro.Instagram/AuthenticationUriFactory.cs
+++ b/src/Solomobro.Instagram/AuthenticationUriFactory.cs
@@ -1,0 +1,34 @@
+﻿using Solomobro.Instagram.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Solomobro.Instagram
+{
+    public class AuthenticationUriFactory
+    {
+        internal static IAuth BuildAuthenticationUri(AuthenticationMethod method, string redirectUri, string clientId)
+        {
+            IAuth authMethod;
+
+            switch(method)
+            {
+                case AuthenticationMethod.Implicit:
+                    authMethod = new ImplicitAuth();
+                    break;
+                default:
+                case AuthenticationMethod.Explicit:
+                    authMethod = new ExplicitAuth();
+                    break;
+            }
+
+            //populate properties of IAuth interface
+            authMethod.RedirectUri = redirectUri;
+            authMethod.ClientId = clientId;
+
+            return authMethod;
+        }
+    }
+}

--- a/src/Solomobro.Instagram/ExplicitAuth.cs
+++ b/src/Solomobro.Instagram/ExplicitAuth.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using Solomobro.Instagram.Interfaces;
+
+namespace Solomobro.Instagram
+{
+    public class ExplicitAuth : IAuth
+    {
+        public AuthenticationMethod Method { get; } = AuthenticationMethod.Explicit;
+        public string BaseAuthUrl { get; } = "https://api.instagram.com";
+        public string ResponseCode { get; } = "code";
+        public string Scope { get; } = new ScopeBuilder().BuildScope();
+        public string ClientId { get; set; }
+        public string RedirectUri { get; set; }
+    }
+}

--- a/src/Solomobro.Instagram/ImplicitAuth.cs
+++ b/src/Solomobro.Instagram/ImplicitAuth.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using Solomobro.Instagram.Interfaces;
+
+namespace Solomobro.Instagram
+{
+    public class ImplicitAuth : IAuth
+    {
+        public AuthenticationMethod Method { get; } = AuthenticationMethod.Implicit;
+        public string BaseAuthUrl { get; } = "https://instagram.com/oauth";
+        public string ResponseCode { get; } = "token";
+        public string Scope { get; } = new ScopeBuilder().BuildScope();
+        public string ClientId { get; set; }
+        public string RedirectUri { get; set; }
+    }
+}

--- a/src/Solomobro.Instagram/Interfaces/IAuth.cs
+++ b/src/Solomobro.Instagram/Interfaces/IAuth.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Solomobro.Instagram.Interfaces
+{
+    internal interface IAuth
+    {
+        AuthenticationMethod Method { get; }
+        string BaseAuthUrl { get; }
+        string Scope { get; }
+        string ResponseCode { get; }
+        string ClientId { get; set; }
+        string RedirectUri { get; set; }
+    }
+}

--- a/src/Solomobro.Instagram/OAuth.cs
+++ b/src/Solomobro.Instagram/OAuth.cs
@@ -9,6 +9,7 @@ using System.Web;
 using Newtonsoft.Json;
 using Solomobro.Instagram.Entities;
 using Solomobro.Instagram.Exceptions;
+using Solomobro.Instagram.Interfaces;
 
 namespace Solomobro.Instagram
 {
@@ -17,27 +18,17 @@ namespace Solomobro.Instagram
     /// </summary>
     public class OAuth
     {
-        private const string BaseAuthUrl = "https://api.instagram.com/oauth";
-        private readonly HashSet<string> _scopes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         private readonly Lazy<Uri> _authUri;
 
         private string _accessToken;
-            
+
         public string ClientId { get; }
 
         public string ClientSecret { get; }
 
         public string RedirectUri { get; }
 
-        /// <summary>
-        /// The authentication method to use. Default: Explicit (server-side)
-        /// </summary>
-        public AuthenticationMethod AuthMethod { get; } = AuthenticationMethod.Explicit;
-
-        public IEnumerable<string> Scopes
-        {
-            get { return _scopes; }
-        }
+        private IAuth AuthMethod { get; }
 
         /// <summary>
         /// True if object has an access token
@@ -79,21 +70,9 @@ namespace Solomobro.Instagram
         public OAuth(string clientId, string clientSecret, string redirectUri, AuthenticationMethod authMethod) 
             : this(clientId, clientSecret, redirectUri)
         {
-            AuthMethod = authMethod;
+            AuthMethod = AuthenticationUriFactory.BuildAuthenticationUri(authMethod, redirectUri, clientId);
         }
 
-        /// <summary>
-        /// Add scopes to the configuration
-        /// </summary>
-        /// <param name="scopes">one or more scopes</param>
-        /// <see cref="OAuthScope"/>
-        public void AddScopes(params string[] scopes)
-        {
-            foreach (var scope in scopes)
-            {
-                _scopes.Add(scope);
-            }
-        }
 
         /// <summary>
         /// Validates your authorization by retrieving the access token from Instagram's reply
@@ -109,7 +88,7 @@ namespace Solomobro.Instagram
                 string accessToken;
                 User user = null;
 
-                switch (AuthMethod)
+                switch (AuthMethod.Method)
                 {
                     case AuthenticationMethod.Implicit:
                         accessToken = GetAccessTokenImplicit(instagramResponseUri);
@@ -124,6 +103,7 @@ namespace Solomobro.Instagram
                 }
 
                 AuthenticateWithAccessToken(accessToken);
+
                 return new AuthenticationResult
                 {
                     Success = true,
@@ -207,13 +187,14 @@ namespace Solomobro.Instagram
         {
             EnsureSuccessUri(uri);
 
-            var parts = uri.Fragment.Split(new[] {'='}, StringSplitOptions.RemoveEmptyEntries);
-            if (parts.Length != 2 || parts[1] != "#access_token")
-            {
-                throw new ArgumentException($"bad uri fragment - {uri.Fragment}");
-            }
+            //var parts = uri.Fragment.Split(new[] {'='}, StringSplitOptions.RemoveEmptyEntries);
+            //if (parts.Length != 2 || parts[1] != "#access_token")
+            //{
+            //    throw new ArgumentException($"bad uri fragment - {uri.Fragment}");
+            //}
 
-            return parts[1];
+            //return parts[1];
+            return uri.AbsoluteUri;
         }
 
         private async Task<ExplicitAuthResponse> GetAuthInfoExplicitAsync(Uri uri)
@@ -225,7 +206,7 @@ namespace Solomobro.Instagram
 
             using (var client = new HttpClient(new HttpClientHandler {AllowAutoRedirect = false}))
             {
-                var accessTokenUri = new Uri($"{BaseAuthUrl}/access_token");
+                var accessTokenUri = new Uri($"{AuthMethod.BaseAuthUrl}/access_token");
                 var data = new FormUrlEncodedContent(new []
                 {
                     new KeyValuePair<string, string>("client_id", ClientId),
@@ -273,41 +254,11 @@ namespace Solomobro.Instagram
 
         private Uri BuildAuthenticationUri()
         {
-            var responseCode = BuildResponseType();
-            var scope = BuildScope();
-
             //todo: this may need url encoding or escaping, especially in building the scope
-            var url = $"{BaseAuthUrl}/authorize/?client_id={ClientId}&redirect_uri={RedirectUri}&response_type={responseCode}&scope={scope}";
+            var url = $"{AuthMethod.BaseAuthUrl}/authorize/?client_id={AuthMethod.ClientId}&redirect_uri={AuthMethod.RedirectUri}&response_type={AuthMethod.ResponseCode}&scope={AuthMethod.Scope}";
 
             return new Uri(url);
         }
 
-        private string BuildResponseType()
-        {
-            switch (AuthMethod)
-            {
-                case AuthenticationMethod.Implicit:
-                    return "token";
-                case AuthenticationMethod.Explicit:
-                    return "code";
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(AuthMethod));
-            }
-        }
-
-        private string BuildScope()
-        {
-            var sb = new StringBuilder(OAuthScope.Basic);
-            if (Scopes.Any())
-            {
-                foreach (var scope in Scopes)
-                {
-                    sb.Append("+");
-                    sb.Append(scope);
-                }
-            }
-
-            return sb.ToString();
-        }
     }
 }

--- a/src/Solomobro.Instagram/ScopeBuilder.cs
+++ b/src/Solomobro.Instagram/ScopeBuilder.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Solomobro.Instagram
+{
+    public class ScopeBuilder
+    {
+        private readonly HashSet<string> _scopes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        public IEnumerable<string> Scopes
+        {
+            get { return _scopes; }
+        }
+        /// <summary>
+        /// Add scopes to the configuration
+        /// </summary>
+        /// <param name="scopes">one or more scopes</param>
+        /// <see cref="OAuthScope"/>
+        private void AddScopes(params string[] scopes)
+        {
+            foreach (var scope in scopes)
+            {
+                _scopes.Add(scope);
+            }
+        }
+
+        /// <summary>
+        ///  Build the scope of this URI
+        /// </summary>
+        /// <returns>scope</returns>
+        public string BuildScope()
+        {
+
+            var sb = new StringBuilder(OAuthScope.Basic);
+            if (Scopes.Any())
+            {
+                foreach (var scope in Scopes)
+                {
+                    sb.Append("+");
+                    sb.Append(scope);
+                }
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/src/Solomobro.Instagram/Solomobro.Instagram.csproj
+++ b/src/Solomobro.Instagram/Solomobro.Instagram.csproj
@@ -48,20 +48,25 @@
   <ItemGroup>
     <Compile Include="Api.cs" />
     <Compile Include="AuthenticationResult.cs" />
+    <Compile Include="AuthenticationUriFactory.cs" />
     <Compile Include="Entities\ExplicitAuthResponse.cs" />
+    <Compile Include="Entities\ImplicitAuthResponse.cs" />
     <Compile Include="Entities\User.cs" />
     <Compile Include="Exceptions\AccessDeniedException.cs" />
     <Compile Include="Exceptions\AlreadyAuthorizedException.cs" />
     <Compile Include="Exceptions\OAuthAccessTokenException.cs" />
     <Compile Include="Exceptions\OAuthException.cs" />
+    <Compile Include="ExplicitAuth.cs" />
+    <Compile Include="ImplicitAuth.cs" />
+    <Compile Include="Interfaces\IAuth.cs" />
     <Compile Include="OAuth.cs" />
     <Compile Include="AuthenticationMethod.cs" />
     <Compile Include="OAuthScope.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ScopeBuilder.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Endpoints\" />
-    <Folder Include="Interfaces\" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />


### PR DESCRIPTION
This breaks out ImplicitAuth and ExplicitAuth into their own classes. This way we decouple their functionality into their own classes and reduce the use of switch statements. Also broke out ScopeBuilder into it's own class. 
